### PR TITLE
add optional syntax folding

### DIFF
--- a/syntax/icalendar.vim
+++ b/syntax/icalendar.vim
@@ -46,6 +46,13 @@ IcalHiLink	icalParameter	Comment
 IcalHiLink	icalSetValue	Special
 IcalHiLink	icalCustom	Error
 
+" to enable syntax folding, add to your vimrc:
+" augroup iCalendarFolding
+"   autocmd!
+"   autocmd FileType icalendar setlocal foldmethod=syntax
+" augroup END
+syntax region icalObject start="^BEGIN:\z([A-Z]\+\)$" end="^END:\z1$" fold transparent keepend extend
+
 delcommand IcalHiLink
   
 let b:current_syntax = "icalendar"


### PR DESCRIPTION
There is also  @Freed-Wu 's https://github.com/Freed-Wu/icalendar-fold.vim/blob/master/autoload/icalendar/fold.vim using expr folding; as this file already adds syntax folding, it seemed a natural choice of folding method